### PR TITLE
Подавление E_WARNING в file_get_contents

### DIFF
--- a/UnisenderApi.php
+++ b/UnisenderApi.php
@@ -264,7 +264,7 @@ class UnisenderApi
 
         do {
             $host = $this->getApiHost();
-            $result = file_get_contents($host.$url, false, $context);
+            $result = @file_get_contents($host.$url, false, $context);
             ++$retryCount;
         } while ($result === false && $retryCount < $this->retryCount);
 


### PR DESCRIPTION
В последнее время сервис частенько отвечает ошибкой 500:

> E_WARNING: file_get_contents(https://api.unisender.com/ru/api/importContacts?format=json): failed to open stream: HTTP request failed! HTTP/1.1 500 Internal Server Error
> File "/....../vendor/unisender/api-wrapper/UnisenderApi.php" line 267 in handleError

В своем приложении я корректно обрабатываю такой ответ (обращаюсь к серверу через какое-то время), но подавить эти E_WARNING не получается. В итоге они только создают информационный шум в логах :-(