### PR TITLE
TLS 1.2 support, PHP 5.6 required

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,16 @@ To use compression you have to install bz2 php extension.
 # Changelog
 v1.2    Since this version, you may specify platform - a new argument. We will track it in our database. This is usefull for us to keep close to all platforms which uses our api. It is not required argument.
 
-#Usage
+v1.5    Since this version, we requrire at least PHP 5.6 to enable TLS 1.2 support. Now English is default locale for api request. 
+
+#Basic usage example
 
 ```
 <?php
+
+require_once 'UnisenderApi.php';
+
+use Unisender\ApiWrapper\UnisenderApi;
 
 $platform = 'My E-commerce product v1.0';
 $UnisenderApi = new UnisenderApi('api key here', 'UTF-8', 4, null, false, $platform);

--- a/UnisenderApi.php
+++ b/UnisenderApi.php
@@ -253,6 +253,9 @@ class UnisenderApi
                 'header' => 'Content-type: application/x-www-form-urlencoded',
                 'content' => $content,
             ],
+            'ssl' => [
+                'crypto_method' => STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT,
+            ]
         ];
 
         if ($this->timeout) {
@@ -276,6 +279,6 @@ class UnisenderApi
      */
     protected function getApiHost()
     {
-        return 'https://api.unisender.com/ru/api/';
+        return 'https://api.unisender.com/en/api/';
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
         }
     ],
     "require": {
-        "php":                          ">=5.4.0"
+        "php": ">=5.6.0",
+        "ext-openssl": "Required for TLS 1.2 encryption"
     },
     "suggest": {
         "ext-bz2": "Allows bzip2 compression"


### PR DESCRIPTION
Support of TLS 1.2 encryption, Now requires PHP 5.6 only.